### PR TITLE
chore: M14-WP7 post-merge housekeeping (M14 complete — 7/7 WPs done)

### DIFF
--- a/implementation/v2/planning/05-milestones/M14-WorkPackages-v1.md
+++ b/implementation/v2/planning/05-milestones/M14-WorkPackages-v1.md
@@ -317,16 +317,16 @@ Activate all remaining institutional and operational agents as real runtime part
 
 ### Tasks
 
-- [ ] Define canonical runtime root: `${OPENQILIN_SYSTEM_ROOT}/projects/<project_id>/` (default: `${HOME}/.openqilin/projects/<project_id>/`); add `OPENQILIN_SYSTEM_ROOT` to `RuntimeSettings` and `.env.example`
-- [ ] Add `storage_uri`, `content_hash` (sha256), and `revision_no` fields to `project_artifact_version` table via Alembic migration
-- [ ] Implement `ArtifactFileStore` in `src/openqilin/data_access/artifact_file_store.py`:
+- [x] Define canonical runtime root: `${OPENQILIN_SYSTEM_ROOT}/projects/<project_id>/` (default: `${HOME}/.openqilin/projects/<project_id>/`); add `OPENQILIN_SYSTEM_ROOT` to `RuntimeSettings` and `.env.example`
+- [x] Add `storage_uri`, `content_hash` (sha256), and `revision_no` fields to `project_artifact_version` table via Alembic migration
+- [x] Implement `ArtifactFileStore` in `src/openqilin/data_access/artifact_file_store.py`:
   - `write(project_id, artifact_type, version_no, content_md)` → writes file to `${OPENQILIN_SYSTEM_ROOT}/projects/<project_id>/<artifact_type>-v{version_no}.md`; computes sha256; returns `(storage_uri, content_hash)`
   - `read(storage_uri)` → returns file content as string
   - Files must never be written to the source repository tree
-- [ ] Wire `ArtifactFileStore` into `project_artifact_repo` write path: every artifact version write calls `ArtifactFileStore.write()` before DB insert; stores `storage_uri` and `content_hash` in DB record
-- [ ] Implement hash integrity check in `DocumentPolicyEnforcer` (WP M14-05): on every artifact write/update, re-compute sha256 of file at `storage_uri`; if mismatch with DB `content_hash`, deny write fail-closed and emit immutable audit event (ProjectArtifactModel §7)
-- [ ] Add unit test: artifact write produces file at canonical path + matching DB `storage_uri` and `content_hash`
-- [ ] Add unit test: hash mismatch between file and DB `content_hash` → write denied; audit event emitted
+- [x] Wire `ArtifactFileStore` into `project_artifact_repo` write path: every artifact version write calls `ArtifactFileStore.write()` before DB insert; stores `storage_uri` and `content_hash` in DB record
+- [x] Implement hash integrity check in `DocumentPolicyEnforcer` (WP M14-05): on every artifact write/update, re-compute sha256 of file at `storage_uri`; if mismatch with DB `content_hash`, deny write fail-closed and emit immutable audit event (ProjectArtifactModel §7)
+- [x] Add unit test: artifact write produces file at canonical path + matching DB `storage_uri` and `content_hash`
+- [x] Add unit test: hash mismatch between file and DB `content_hash` → write denied; audit event emitted
 
 ### Outputs
 
@@ -336,10 +336,10 @@ Activate all remaining institutional and operational agents as real runtime part
 
 ### Done criteria
 
-- [ ] Artifact write produces file at `${OPENQILIN_SYSTEM_ROOT}/projects/<project_id>/` path
-- [ ] `storage_uri` and `content_hash` stored in `project_artifact_version` DB row
-- [ ] No project artifact file written under the source repository directory
-- [ ] Hash mismatch between DB and file → write denied fail-closed; audit event emitted (ProjectArtifactModel §7)
+- [x] Artifact write produces file at `${OPENQILIN_SYSTEM_ROOT}/projects/<project_id>/` path
+- [x] `storage_uri` and `content_hash` stored in `project_artifact_version` DB row
+- [x] No project artifact file written under the source repository directory
+- [x] Hash mismatch between DB and file → write denied fail-closed; audit event emitted (ProjectArtifactModel §7)
 
 ---
 

--- a/implementation/v2/planning/ImplementationProgress-v2.md
+++ b/implementation/v2/planning/ImplementationProgress-v2.md
@@ -13,7 +13,7 @@ Tracking authority: GitHub Issues/PRs are the operational source of truth. This 
 | M11 | `done` | 4 / 4 | All WPs complete; exit criteria met |
 | M12 | `done` | 8 / 8 | All WPs done; PR #88 raised; exit criteria partially met (compose stack validation pending prod) |
 | M13 | `done` | 9 / 9 | All WPs complete; exit criteria met; WPs #89–#96, #98 |
-| M14 | `in_progress` | 5 / 7 | Entry gate: M13 complete; all remaining agents + file-backed artifact storage |
+| M14 | `done` | 7 / 7 | All WPs complete; exit criteria met |
 | M15 | `planned` | 0 / 6 | Entry gate: M14 complete |
 | M16 | `planned` | 0 / 5 | Entry gate: M15 complete |
 | M17 | `planned` | 0 / 6 | Entry gate: M16 complete |
@@ -85,10 +85,10 @@ WP document: `05-milestones/M14-WorkPackages-v1.md`
 | M14-WP3 | CWO Agent | `done` | #105 | #106 | Command authority (decision=deny+advisory=deny); reads completion_report before co-approval; project_charter write; full DecisionReviewGates; 560 unit tests pass |
 | M14-WP4 | Auditor Agent | `done` | #108 | #110 | ESC-005/006 CEO+owner pause notification; project-doc compliance monitoring; behavioral violation path; 583 unit tests pass |
 | M14-WP5 | Administrator Agent | `done` | #113 | #114 | AdministratorAgent + DocumentPolicyEnforcer + RetentionEnforcer; quarantine_agent; 5 administrator artifact types; 666 unit+component tests pass; Node.js 24 CI fix |
-| M14-WP6 | Specialist Agent and Task Execution Engine | `pending` | — | — | Writes task_execution_results NOT project artifacts (spec conflict resolved); Specialist→DL path |
-| M14-WP7 | File-Backed Artifact Storage | `pending` | — | — | Canonical OPENQILIN_SYSTEM_ROOT path; storage_uri + content_hash in DB; ProjectArtifactModel §2.1/§7 |
+| M14-WP6 | Specialist Agent and Task Execution Engine | `done` | #116 | #117 | Writes task_execution_results NOT project artifacts (spec conflict resolved); Specialist→DL path; 683 unit tests pass |
+| M14-WP7 | File-Backed Artifact Storage | `done` | #118 | #119 | ArtifactFileStore; file:// storage_uri + content_hash in DB; verify_storage_uri_hash in DocumentPolicyEnforcer; 693 unit+component tests pass |
 
-**M14 Exit criteria:** `in_progress`
+**M14 Exit criteria:** `done`
 
 ---
 


### PR DESCRIPTION
## Summary
- Mark M14-WP6 and M14-WP7 `done` in `ImplementationProgress-v2.md`; M14 milestone status → `done` (7/7 WPs)
- Check all M14-WP7 task and done-criteria boxes in `M14-WorkPackages-v1.md`
- GitHub: closed issue #118, updated M14 tracker #100 to done, opened #120 for pre-existing REVIEW_NOTEs

## Milestone / WP
- Milestone: M14 — complete
- WP: M14-WP7 post-merge housekeeping

## Scope
- In scope: planning doc updates only — no source code changes
- Out of scope: REVIEW_NOTE resolution (tracked in #120)

## Validation Commands Run
```bash
# Docs-only change — no tests to run
uv run ruff check .   # PASS (no .py changes)
```

Closes #118