### PR TITLE
chore: M15-WP5 post-merge housekeeping

### DIFF
--- a/implementation/v2/planning/05-milestones/M15-WorkPackages-v1.md
+++ b/implementation/v2/planning/05-milestones/M15-WorkPackages-v1.md
@@ -160,17 +160,17 @@ Replace the in-memory integer budget counter with a real PostgreSQL-backed budge
 
 ### Tasks
 
-- [ ] Create `ops/grafana/provisioning/dashboards/dashboard.yaml` — dashboard provisioning config pointing to `ops/grafana/dashboards/`
-- [ ] Build `ops/grafana/dashboards/operator-main.json` with 6 required panels:
+- [x] Create `ops/grafana/provisioning/dashboards/dashboard.yaml` — dashboard provisioning config pointing to `ops/grafana/dashboards/`
+- [x] Build `ops/grafana/dashboards/operator-main.json` with 6 required panels:
   - **Owner Inbox** — pending approvals, escalations, proposals from `tasks` and `governance_artifacts` (PostgreSQL)
   - **Projects Overview** — all projects: status, blockers, lifecycle state (PostgreSQL)
   - **Project Detail** — per-project activity, task counts, cost (PostgreSQL; project selector variable)
   - **Budget and Cost** — `budget_events` by project, by role, over time; active reservations (PostgreSQL)
   - **System and Runtime Health** — agent liveness, LLM call latency, error rates (Prometheus); span traces (Tempo)
   - **Audit and Governance Events** — `audit_events`: event_type, principal, policy_version, rule_ids (PostgreSQL)
-- [ ] Set dashboard refresh: 30s default; budget/audit panels configurable to 5m
-- [ ] Update `compose.yml` Grafana service: volume-mount `ops/grafana/provisioning` and `ops/grafana/dashboards`
-- [ ] Smoke test: all 6 panels return data after inserting test rows into PostgreSQL and emitting test spans
+- [x] Set dashboard refresh: 30s default; budget/audit panels configurable to 5m
+- [x] Update `compose.yml` Grafana service: volume-mount `ops/grafana/provisioning` and `ops/grafana/dashboards`
+- [x] Smoke test: all 6 panels return data after inserting test rows into PostgreSQL and emitting test spans
 
 ### Outputs
 
@@ -179,12 +179,12 @@ Replace the in-memory integer budget counter with a real PostgreSQL-backed budge
 
 ### Done criteria
 
-- [ ] All 6 panels render without errors after minimal test data insertion
-- [ ] Owner Inbox panel shows pending tasks from `tasks` table
-- [ ] Budget panel shows cost by project from `budget_events`
-- [ ] System Health panel shows metrics from Prometheus
-- [ ] Audit panel shows events from `audit_events`
-- [ ] Owner can identify blocked projects, pending decisions, budget risk, and system health in under 2 minutes
+- [x] All 6 panels render without errors after minimal test data insertion
+- [x] Owner Inbox panel shows pending tasks from `tasks` table
+- [x] Budget panel shows cost by project from `budget_events`
+- [x] System Health panel shows metrics from Prometheus
+- [x] Audit panel shows events from `audit_events`
+- [x] Owner can identify blocked projects, pending decisions, budget risk, and system health in under 2 minutes
 
 ---
 

--- a/implementation/v2/planning/ImplementationProgress-v2.md
+++ b/implementation/v2/planning/ImplementationProgress-v2.md
@@ -14,7 +14,7 @@ Tracking authority: GitHub Issues/PRs are the operational source of truth. This 
 | M12 | `done` | 8 / 8 | All WPs done; PR #88 raised; exit criteria partially met (compose stack validation pending prod) |
 | M13 | `done` | 9 / 9 | All WPs complete; exit criteria met; WPs #89–#96, #98 |
 | M14 | `done` | 7 / 7 | All WPs complete; exit criteria met |
-| M15 | `active` | 4 / 6 | Entry gate: M14 complete ✅; WP5 in_progress |
+| M15 | `active` | 5 / 6 | Entry gate: M14 complete ✅ |
 | M16 | `planned` | 0 / 5 | Entry gate: M15 complete |
 | M17 | `planned` | 0 / 6 | Entry gate: M16 complete |
 
@@ -102,7 +102,7 @@ WP document: `05-milestones/M15-WorkPackages-v1.md`
 | M15-WP2 | Token-Based Cost Model | `done` | #127 | #128 | TokenCostEvaluator; settle() wired; threshold_evaluator deleted; 717 tests pass |
 | M15-WP3 | Budget Obligation Enforcement | `done` | #130 | #131 | reserve_budget obligation wired; budget_reservation_node removed; Rego allow→allow_with_obligations; 725 tests pass |
 | M15-WP4 | Bug Fixes: M-4 and M-5 | `done` | #133 | #134 | BudgetConfigurationError on None client; bootstrap idempotency; 731 tests pass |
-| M15-WP5 | Grafana Dashboard Build | `in_progress` | #136 | — | — |
+| M15-WP5 | Grafana Dashboard Build | `done` | #136 | #137 | 7-panel dashboard JSON + provisioner config + compose mount; 731 tests pass |
 | M15-WP6 | Grafana Alerting and Discord Webhook | `pending` | — | — | — |
 
 **M15 Exit criteria:** `pending`


### PR DESCRIPTION
## Summary
- Mark M15-WP5 `done` in `ImplementationProgress-v2.md` (5/6 WPs done)
- Check all task and done-criteria checkboxes in `M15-WorkPackages-v1.md`
- GitHub issue #136 closed

## Test plan
- [x] Docs-only change; no code modified

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)