### PR TITLE
docs: M16 done — update planning docs status

### DIFF
--- a/implementation/v2/planning/00-direction/MvpV2SuccessCriteria-v1.md
+++ b/implementation/v2/planning/00-direction/MvpV2SuccessCriteria-v1.md
@@ -1,8 +1,8 @@
 # OpenQilin MVP-v2 Success Criteria
 
 Date: `2026-03-14`
-Status: `discussion draft`
-Stage: `pre-kickoff`
+Status: `active`
+Stage: `M17-in-progress`
 
 ## 1. Purpose
 

--- a/implementation/v2/planning/05-milestones/MvpV2MilestonePlan-v1.md
+++ b/implementation/v2/planning/05-milestones/MvpV2MilestonePlan-v1.md
@@ -20,10 +20,10 @@ Full success bar: `00-direction/MvpV2SuccessCriteria-v1.md`
 |---|---|---|---|---|
 | M11 | Discord Grammar and Secretary Activation | `done` | M10 complete | Free-text + `/oq` command UX live; Secretary active; C-7 fixed |
 | M12 | Infrastructure Wiring, Security Hardening, CSO Activation | `done` | M11 complete | OPA, PostgreSQL, Redis, OTel all wired; all C/H security fixes applied; CSO wired |
-| M13 | Project Space Binding, Routing, Orchestration, and Agent Spec Fixes | `planned` | M12 complete | LangGraph active; project spaces bound; DL virtual agent active; H-3 fixed; CSO rewritten as Chief Strategy Officer; Secretary spec aligned |
-| M14 | Executive and Operational Agent Activation | `planned` | M13 complete | PM, CEO, CWO, Auditor, Administrator, Specialist agents active; DecisionReviewGates flow wired |
-| M15 | Budget Persistence, Real Cost Model, and Grafana Dashboard | `planned` | M14 complete | PostgreSQL budget ledger live; token cost model active; Grafana dashboard provisioned with 6 panels |
-| M16 | Onboarding, Diagnostics, and Runtime Polish | `planned` | M15 complete | RuntimeSettings singleton; conversation persistence; idempotency namespaced; doctor CLI working |
+| M13 | Project Space Binding, Routing, Orchestration, and Agent Spec Fixes | `done` | M12 complete | LangGraph active; project spaces bound; DL virtual agent active; H-3 fixed; CSO rewritten as Chief Strategy Officer; Secretary spec aligned |
+| M14 | Executive and Operational Agent Activation | `done` | M13 complete | PM, CEO, CWO, Auditor, Administrator, Specialist agents active; DecisionReviewGates flow wired |
+| M15 | Budget Persistence, Real Cost Model, and Grafana Dashboard | `done` | M14 complete | PostgreSQL budget ledger live; token cost model active; Grafana dashboard provisioned with 6 panels |
+| M16 | Onboarding, Diagnostics, and Runtime Polish | `done` | M15 complete | RuntimeSettings singleton; conversation persistence; idempotency namespaced; doctor CLI working |
 | M17 | Open-Source and Sponsorship Readiness | `planned` | M16 complete | README, demo, roadmap, website, contributor path, sponsorship assets all published |
 
 ---


### PR DESCRIPTION
## Summary
- `MvpV2MilestonePlan-v1.md`: M13, M14, M15, M16 status `planned` → `done`
- `MvpV2SuccessCriteria-v1.md`: Status `discussion draft` → `active`; Stage `pre-kickoff` → `M17-in-progress`

## Test plan
- [ ] Docs-only change — no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)