### PR TITLE
fix: group-channel single-bot gate and advisory response display

### DIFF
--- a/src/openqilin/apps/discord_bot_worker.py
+++ b/src/openqilin/apps/discord_bot_worker.py
@@ -799,6 +799,22 @@ class OpenQilinDiscordClient(discord.Client):
         except DiscordRecipientResolutionError as error:
             await message.channel.send(f"[denied] code={error.code} message={error.message}")
             return
+        # Group-channel single-bot gate: prevent all bots from forwarding the same message.
+        # In DMs only the addressed bot ever receives the message, so no gate needed.
+        if chat_class != "direct":
+            _is_runtime = _is_runtime_placeholder_recipients(resolved_recipients)
+            if _is_runtime:
+                # Free-text with no explicit mention: Secretary is the designated group handler.
+                if self._config.bot_role != "secretary":
+                    return
+            else:
+                # Explicit @mention: only process if this bot is among the resolved recipients.
+                _this_bot_is_target = any(
+                    r[0] == self._config.bot_id or r[1] == self._config.bot_role
+                    for r in resolved_recipients
+                )
+                if not _this_bot_is_target:
+                    return
         project_id = parsed.project_id
         if project_id is None and chat_class == "project":
             project_id = _derive_project_id(message.channel)

--- a/src/openqilin/discord_runtime/bridge.py
+++ b/src/openqilin/discord_runtime/bridge.py
@@ -193,7 +193,9 @@ def format_governed_response(*, status_code: int, body: Mapping[str, object]) ->
             )
             llm_execution = data.get("llm_execution")
             if isinstance(llm_execution, dict):
-                generated_text = llm_execution.get("generated_text")
+                generated_text = llm_execution.get("generated_text") or llm_execution.get(
+                    "advisory_response"
+                )
                 if isinstance(generated_text, str) and generated_text.strip():
                     normalized = generated_text.strip().replace("\n", " ")
                     recipient_role = str(llm_execution.get("recipient_role", "")).strip().lower()


### PR DESCRIPTION
## Summary
- Only one bot forwards each message in group channels: Secretary for free-text, the @mentioned bot for explicit commands
- Secretary's advisory response text is now shown in Discord instead of being silently dropped

## Root causes
1. All 7 bots independently processed every group-channel message and posted to the control plane (different `principal_id` per bot bypassed idempotency dedup), causing 7× `[accepted]` responses and `response_order_timeout`
2. `format_governed_response` checked `llm_execution.generated_text` but the Secretary bypass sends `advisory_response` — text was discarded

## Test plan
- [ ] CI passes (static + unit + component + integration)
- [ ] In a group channel, free-text → only Secretary responds
- [ ] In a group channel, `@mention /oq` → only the mentioned bot responds
- [ ] DMs continue to work as before
- [ ] "Hello" to Secretary DM shows actual advisory text, not just `[accepted]`

Fixes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)