### PR TITLE
fix: show only response text in Discord, drop [accepted] header

### DIFF
--- a/src/openqilin/discord_runtime/bridge.py
+++ b/src/openqilin/discord_runtime/bridge.py
@@ -197,11 +197,7 @@ def format_governed_response(*, status_code: int, body: Mapping[str, object]) ->
                     "advisory_response"
                 )
                 if isinstance(generated_text, str) and generated_text.strip():
-                    normalized = generated_text.strip().replace("\n", " ")
-                    recipient_role = str(llm_execution.get("recipient_role", "")).strip().lower()
-                    role_label = recipient_role or "llm"
-                    role_prefix = f"\n[{role_label}] "
-                    return f"{summary}{role_prefix}{normalized}"
+                    return generated_text.strip()
             return summary
         return f"[accepted] trace={trace_id}"
     if status_value in {"denied", "error"}:


### PR DESCRIPTION
## Summary
- When the control plane returns advisory/generated text, display just that text in Discord
- Removes the `[accepted] trace=... task=... command=... replayed=False` metadata header that was prepended before the actual response

## Test plan
- [ ] DM Secretary → response shows plain text only
- [ ] Group channel free-text → Secretary responds with plain text only

🤖 Generated with [Claude Code](https://claude.com/claude-code)