### PR TITLE
fix: Secretary conversational memory and addressed-agent context for @mentions

### DIFF
--- a/src/openqilin/agents/secretary/agent.py
+++ b/src/openqilin/agents/secretary/agent.py
@@ -26,6 +26,7 @@ from openqilin.llm_gateway.schemas.requests import (
     LlmPolicyContext,
 )
 from openqilin.llm_gateway.service import LlmGatewayService
+from openqilin.task_orchestrator.dispatch.llm_dispatch import ConversationStoreProtocol
 
 # Secretary NEVER handles mutation or admin intents
 _DENIED_INTENTS: frozenset[IntentClass] = frozenset({IntentClass.MUTATION, IntentClass.ADMIN})
@@ -59,11 +60,14 @@ class SecretaryAgent:
 
     def __init__(
         self,
+        *,
         llm_gateway: LlmGatewayService,
         data_access: SecretaryDataAccessService | None = None,
+        conversation_store: ConversationStoreProtocol | None = None,
     ) -> None:
         self._llm = llm_gateway
         self._data_access = data_access
+        self._conversation_store = conversation_store
 
     def handle(self, request: SecretaryRequest) -> SecretaryResponse:
         """Handle advisory request. Raises SecretaryPolicyError for mutation/admin intents."""
@@ -108,10 +112,33 @@ class SecretaryAgent:
                 chat_class=request.context.chat_class,
                 message=request.message[:500],
             )
+        if request.addressed_agent:
+            agent_context = (
+                f"Note: the user directed this message at the {request.addressed_agent} agent. "
+                f"Acknowledge this and frame your response in the context of the {request.addressed_agent}'s role "
+                f"(e.g. what they handle, how to interact with them via /oq commands)."
+            )
+            prompt = f"{agent_context}\n\n{prompt}"
         if project_context:
             prompt = f"{prompt}{project_context}"
 
-        full_prompt = f"{ADVISORY_SYSTEM_PROMPT}\n\n{prompt}"
+        if self._conversation_store and request.channel_id:
+            scope = f"discord:{request.channel_id}"
+            history = self._conversation_store.list_turns(scope)
+            if history:
+                history_lines = []
+                for turn in history:
+                    prefix = "User" if turn.role == "user" else "Secretary"
+                    history_lines.append(f"{prefix}: {turn.content}")
+                history_text = "\n".join(history_lines)
+                full_prompt = (
+                    f"{ADVISORY_SYSTEM_PROMPT}\n\nConversation so far:\n{history_text}\n\n{prompt}"
+                )
+            else:
+                full_prompt = f"{ADVISORY_SYSTEM_PROMPT}\n\n{prompt}"
+        else:
+            full_prompt = f"{ADVISORY_SYSTEM_PROMPT}\n\n{prompt}"
+
         response = self._llm.complete(
             LlmGatewayRequest(
                 request_id=str(uuid.uuid4()),
@@ -130,9 +157,19 @@ class SecretaryAgent:
             )
         )
 
-        if response.decision in ("served", "fallback_served") and response.generated_text:
-            return response.generated_text.strip()
-        return _FALLBACK_ADVISORY
+        result = (
+            response.generated_text.strip()
+            if response.decision in ("served", "fallback_served") and response.generated_text
+            else _FALLBACK_ADVISORY
+        )
+        if self._conversation_store and request.channel_id:
+            scope = f"discord:{request.channel_id}"
+            self._conversation_store.append_turns(
+                scope,
+                user_prompt=request.message,
+                assistant_reply=result,
+            )
+        return result
 
 
 def _build_routing_suggestion(request: SecretaryRequest) -> str | None:

--- a/src/openqilin/agents/secretary/models.py
+++ b/src/openqilin/agents/secretary/models.py
@@ -15,6 +15,9 @@ class SecretaryRequest:
     intent: IntentClass
     context: ChatContext
     trace_id: str
+    channel_id: str = ""
+    actor_id: str = ""
+    addressed_agent: str = ""
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/openqilin/control_plane/api/dependencies.py
+++ b/src/openqilin/control_plane/api/dependencies.py
@@ -237,7 +237,6 @@ def build_runtime_services() -> RuntimeServices:
         governance_repo=governance_repo,
         runtime_state_repo=runtime_state_repo,
     )
-    secretary_agent = SecretaryAgent(llm_gateway=llm_gateway, data_access=secretary_data_access)
     artifact_writer = PMProjectArtifactWriter(project_artifact_repo=project_artifact_repo)
 
     # --- idempotency (Redis required) ------------------------------------
@@ -298,6 +297,11 @@ def build_runtime_services() -> RuntimeServices:
         PostgresConversationStore(session_factory=session_factory, max_turns=6)
         if settings.runtime_persistence_enabled
         else None
+    )
+    secretary_agent = SecretaryAgent(
+        llm_gateway=llm_gateway,
+        data_access=secretary_data_access,
+        conversation_store=conversation_store,
     )
     tracer = InMemoryTracer()
     # OTelAuditWriter with durable Postgres write (AUD-001).

--- a/src/openqilin/control_plane/routers/discord_ingress.py
+++ b/src/openqilin/control_plane/routers/discord_ingress.py
@@ -207,11 +207,21 @@ def submit_discord_message(
                         },
                     },
                 )
+            _addressed_agent = ""
+            for _r in payload.recipients:
+                _rt = _r.recipient_type.strip().lower() if _r.recipient_type else ""
+                if _rt and _rt not in ("runtime", "secretary", ""):
+                    _addressed_agent = _rt
+                    break
+
             sec_req = SecretaryRequest(
                 message=content,
                 intent=intent,
                 context=grammar_context,
                 trace_id=payload.trace_id,
+                channel_id=payload.channel_id,
+                actor_id=payload.actor_external_id,
+                addressed_agent=_addressed_agent,
             )
             try:
                 sec_resp = secretary_agent.handle(sec_req)

--- a/tests/unit/test_m11_wp3_secretary_agent.py
+++ b/tests/unit/test_m11_wp3_secretary_agent.py
@@ -12,6 +12,9 @@ Covers:
 
 from __future__ import annotations
 
+from typing import cast
+from unittest.mock import MagicMock
+
 import pytest
 
 from openqilin.agents.secretary.agent import SecretaryAgent
@@ -23,7 +26,37 @@ from openqilin.control_plane.identity.discord_governance import (
     _PENDING_ROLE_FLAGS,
 )
 from openqilin.llm_gateway.providers.litellm_adapter import InMemoryLiteLLMAdapter
+from openqilin.llm_gateway.schemas.requests import LlmPolicyContext
+from openqilin.llm_gateway.schemas.responses import LlmGatewayResponse
 from openqilin.llm_gateway.service import LlmGatewayService
+from openqilin.task_orchestrator.dispatch.llm_dispatch import (
+    ConversationStoreProtocol,
+    ConversationTurn,
+)
+
+
+_POLICY_CONTEXT = LlmPolicyContext(
+    policy_version="v2",
+    policy_hash="test-policy",
+    rule_ids=(),
+)
+
+
+def _served_response(text: str) -> LlmGatewayResponse:
+    return LlmGatewayResponse(
+        request_id="req-1",
+        trace_id="trace-1",
+        decision="served",
+        model_selected="model-test",
+        usage=None,
+        cost=None,
+        budget_usage=None,
+        budget_context_effective=None,
+        quota_limit_source="policy_guardrail",
+        latency_ms=1,
+        policy_context=_POLICY_CONTEXT,
+        generated_text=text,
+    )
 
 
 def _make_agent() -> SecretaryAgent:
@@ -112,6 +145,66 @@ class TestSecretaryAgentPolicyProfile:
             self.agent.handle(req)
         assert exc.value.code == "secretary_advisory_policy_denied"
         assert "admin" in exc.value.message.lower()
+
+
+# ---------------------------------------------------------------------------
+# Secretary memory and mention context (M17 fix)
+# ---------------------------------------------------------------------------
+
+
+class TestSecretaryConversationAndMentionContext:
+    def test_channel_scoped_history_is_used_and_turn_is_persisted(self) -> None:
+        llm = MagicMock()
+        llm.complete.return_value = _served_response("History-aware advisory")
+        conversation_store = MagicMock()
+        conversation_store.list_turns.return_value = (
+            ConversationTurn(role="user", content="Previous user question"),
+            ConversationTurn(role="assistant", content="Previous secretary answer"),
+        )
+        agent = SecretaryAgent(
+            llm_gateway=cast(LlmGatewayService, llm),
+            conversation_store=cast(ConversationStoreProtocol, conversation_store),
+        )
+        req = SecretaryRequest(
+            message="What should we do next?",
+            intent=IntentClass.QUERY,
+            context=_ctx("governance"),
+            trace_id="trace-m17-fix-001",
+            channel_id="channel-123",
+            actor_id="owner-123",
+        )
+
+        resp = agent.handle(req)
+
+        assert resp.advisory_text == "History-aware advisory"
+        conversation_store.list_turns.assert_called_once_with("discord:channel-123")
+        conversation_store.append_turns.assert_called_once_with(
+            "discord:channel-123",
+            user_prompt="What should we do next?",
+            assistant_reply="History-aware advisory",
+        )
+        sent_prompt = llm.complete.call_args.args[0].messages_or_prompt
+        assert "Conversation so far:" in sent_prompt
+        assert "User: Previous user question" in sent_prompt
+        assert "Secretary: Previous secretary answer" in sent_prompt
+
+    def test_addressed_agent_context_is_included_in_prompt(self) -> None:
+        llm = MagicMock()
+        llm.complete.return_value = _served_response("Mention-aware advisory")
+        agent = SecretaryAgent(llm_gateway=cast(LlmGatewayService, llm))
+        req = SecretaryRequest(
+            message="Can you help me run policy checks?",
+            intent=IntentClass.DISCUSSION,
+            context=_ctx("executive"),
+            trace_id="trace-m17-fix-002",
+            addressed_agent="administrator",
+        )
+
+        agent.handle(req)
+
+        sent_prompt = llm.complete.call_args.args[0].messages_or_prompt
+        assert "directed this message at the administrator agent" in sent_prompt
+        assert "context of the administrator's role" in sent_prompt
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- wire `ConversationStoreProtocol` into `SecretaryAgent` and persist advisory turns by Discord channel scope
- add Secretary request context fields: `channel_id`, `actor_id`, and `addressed_agent`
- pass channel/actor/mention recipient context from Discord ingress into Secretary advisory bypass
- include addressed-agent framing in Secretary advisory prompt for explicit @mention flows

## Linked Issue
- refs #177

## Validation
- `uv run python -m ruff check . && uv run python -m ruff format --check . && uv run python -m mypy .`
- `uv run python -m pytest tests/unit tests/component -x --tb=short -q`
