### PR TITLE
chore: M17-WP8 post-merge housekeeping (6/9 WPs done)

### DIFF
--- a/implementation/v2/planning/05-milestones/M17-WorkPackages-v1.md
+++ b/implementation/v2/planning/05-milestones/M17-WorkPackages-v1.md
@@ -243,9 +243,66 @@ Prepare OpenQilin for public introduction, early contributors, and realistic spo
 
 ---
 
+## WP M17-08 — Conversation Memory Foundation
+
+**Goal:** Establish unified per-channel conversation scope, increase the hot window from 6 to 40 rows (20 exchanges), and introduce windowed warm-tier summarization so all agents in a channel share a coherent transcript.
+
+**Design ref:** `design/v2/architecture/ConversationMemoryDesign-v1.md`
+
+### Tasks
+
+- [x] Unify conversation scope key: replace `"{project}::{guild}::{channel}::{thread}::{role}::{agent_id}"` with `"guild::{guild_id}::channel::{channel_id}"` in `LlmGatewayDispatchAdapter._conversation_scope()`
+- [x] Align Secretary scope: update `discord_ingress.py` to pass the unified scope key (not `"discord:{channel_id}"`)
+- [x] Increase `max_turns` from 6 to 40 and add `ConversationMemoryConfig` dataclass
+- [x] Alembic migration: add `agent_id TEXT` and `window_index INTEGER` to `conversation_messages`
+- [x] Alembic migration: create `conversation_windows` table
+- [x] Implement `list_windows(scope)` and `fetch_window(scope, window_index)` in `PostgresConversationStore`
+- [x] Synchronous window summary generation on window close (injected `summarize_fn`, non-fatal)
+- [x] Update `_compose_role_locked_prompt()` to include warm summaries before hot turns
+- [x] Update unit and component tests
+
+### Done criteria
+
+- [x] All agents in the same channel share one `conversation_messages` scope
+- [x] Warm summaries generated and loaded after a window fills (40 rows)
+- [x] `max_turns=40` default; old `max_turns=6` removed
+- [x] Static checks and unit/component tests pass (829 passed)
+
+---
+
+## WP M17-09 — Semantic Fetch and Agent Tool
+
+**Goal:** Give agents autonomous context retrieval — proactive semantic pre-fetch of relevant cold windows before each LLM call, and a reactive tool for mid-reasoning history lookup. Add cross-channel summary fetch for on-demand context from other channels or DMs.
+
+**Design ref:** `design/v2/architecture/ConversationMemoryDesign-v1.md`
+
+### Tasks
+
+- [ ] Add `summary_embedding vector(1536)` column to `conversation_windows` (Alembic migration)
+- [ ] Add `ivfflat` index on `summary_embedding` using `vector_cosine_ops`
+- [ ] Async embedding generation for window summaries (background task after summary write)
+- [ ] Implement `find_relevant_windows(scope, query_embedding, threshold, limit)` via pgvector ANN
+- [ ] Wire proactive semantic pre-fetch into `LlmGatewayDispatchAdapter.load_context()`
+- [ ] Register `get_conversation_window(window_index, scope?)` as LangGraph tool for all async agents
+- [ ] Implement `fetch_channel_summary(target_scope)` in store
+- [ ] Wire `/oq context from:#channel-name` command in `discord_ingress.py`
+- [ ] Add `context_sources: list[str]` field to `TaskPayload`
+- [ ] Wire proactive semantic pre-fetch into Secretary sync path
+- [ ] Integration tests (require postgres + pgvector)
+
+### Done criteria
+
+- [ ] Agent receives relevant cold window content without user prompting (proactive fetch)
+- [ ] Agent can call `get_conversation_window` tool mid-reasoning
+- [ ] `/oq context from:#channel` attaches summary to next invocation
+- [ ] DM scope cross-channel fetch restricted to participating bot only
+- [ ] Integration tests pass with compose stack
+
+---
+
 ## M17 Exit Criteria
 
-- [ ] All seven WPs above are marked done
+- [ ] All nine WPs above are marked done
 - [ ] README, CONTRIBUTING.md, CODE_OF_CONDUCT.md, ROADMAP.md all live in repo root
 - [ ] Demo runs end-to-end on clean checkout
 - [ ] Public domain and contact email live

--- a/implementation/v2/planning/ImplementationProgress-v2.md
+++ b/implementation/v2/planning/ImplementationProgress-v2.md
@@ -16,7 +16,7 @@ Tracking authority: GitHub Issues/PRs are the operational source of truth. This 
 | M14 | `done` | 7 / 7 | All WPs complete; exit criteria met |
 | M15 | `done` | 6 / 6 | All WPs complete; exit criteria met |
 | M16 | `done` | 5 / 5 | All WPs complete; exit criteria met |
-| M17 | `in_progress` | 5 / 7 | WP1-WP2-WP4-WP6-WP7 done |
+| M17 | `in_progress` | 6 / 9 | WP1-WP2-WP4-WP6-WP7-WP8 done; WP3-WP5 pending; WP9 pending |
 
 ---
 
@@ -138,6 +138,8 @@ WP document: `05-milestones/M17-WorkPackages-v1.md`
 | M17-WP5 | Website and Public Presence | `pending` | — | — | — |
 | M17-WP6 | Sponsorship and Startup-Credit Readiness | `done` | #166 | #167 | GitHub Sponsors repo wiring complete: funding config moved to `.github/FUNDING.yml`; sponsorship docs updated; README sponsor badge/link added; profile status marked active |
 | M17-WP7 | Auto-create Discord Project Channel on Initialization | `done` | #168 | #169 | DiscordChannelAutomator now calls Discord REST API; `guild_id` added to initialization payload; binding service wired into runtime + governance initialize non-fatal auto-bind path; unit tests added |
+| M17-WP8 | Conversation Memory Foundation | `done` | #179 | #182 | Unified scope key; hot window 6→40; conversation_windows table; warm loading; 829 tests pass |
+| M17-WP9 | Semantic Fetch and Agent Tool | `pending` | #180 | — | pgvector ANN pre-fetch; get_conversation_window tool; cross-channel fetch |
 
 **M17 Exit criteria:** `pending`
 


### PR DESCRIPTION
## Summary

- Mark M17-WP8 `done` in `ImplementationProgress-v2.md`
- Add WP8 (all tasks checked ✅) and WP9 sections to `M17-WorkPackages-v1.md` (lost during rebase)
- M17 progress: 6 / 9 WPs complete (WP1-WP2-WP4-WP6-WP7-WP8 done)

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)