### PR TITLE
fix: worker resilience — one bot crash no longer kills all; expand connector retry

### DIFF
--- a/src/openqilin/apps/discord_bot_worker.py
+++ b/src/openqilin/apps/discord_bot_worker.py
@@ -221,7 +221,7 @@ class DiscordIngressFanIn:
                     json=payload,
                 )
                 break
-            except (httpx.ConnectError, httpx.RemoteProtocolError) as error:
+            except httpx.TransportError as error:
                 LOGGER.warning(
                     "discord.worker.connector_error",
                     message_id=event.message_id,
@@ -976,9 +976,17 @@ async def run_worker_launch_plan(plan: DiscordWorkerLaunchPlan) -> None:
         for config in plan.configs
     ]
     try:
-        await asyncio.gather(
+        results = await asyncio.gather(
             *(client.start(config.token) for client, config in zip(clients, plan.configs)),
+            return_exceptions=True,
         )
+        for config, result in zip(plan.configs, results):
+            if isinstance(result, BaseException):
+                LOGGER.error(
+                    "discord.worker.client_fatal_error",
+                    bot_role=config.bot_role,
+                    error=str(result),
+                )
     finally:
         await asyncio.gather(*(client.close() for client in clients), return_exceptions=True)
         await fan_in.close()


### PR DESCRIPTION
## Summary

- **Fix 1 — Multi-bot crash resilience:** `run_worker_launch_plan` now uses `asyncio.gather(..., return_exceptions=True)`. One bot raising a fatal exception (e.g., CSO gateway error) no longer cancels the other 6 bots. Fatal errors are logged via `discord.worker.client_fatal_error`.
- **Fix 2 — Expand connector retry scope:** Retry condition broadened from `ConnectError | RemoteProtocolError` to `httpx.TransportError`, covering `ReadError`, `WriteError`, `PoolTimeout`, timeout exceptions etc. Non-transport errors still fail immediately.

## Root cause

At 06:56:17, `cso_bot` had a fatal Discord gateway disconnection. `asyncio.gather` (without `return_exceptions=True`) cancelled all 7 bot tasks, crashing the container. Docker restarted it.

## Test plan

- [ ] Kill one bot's token mid-session → other 6 bots continue serving
- [ ] `discord.worker.client_fatal_error` logged for the failed bot
- [ ] Container no longer restarts on single-bot disconnect
- [ ] 880 unit/component tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)