### PR TITLE
fix: /oq ask <agent> in group channels routes without requiring Discord @mention

### DIFF
--- a/src/openqilin/apps/discord_bot_worker.py
+++ b/src/openqilin/apps/discord_bot_worker.py
@@ -902,8 +902,14 @@ class OpenQilinDiscordClient(discord.Client):
                 if self._config.bot_role != "secretary" and not _this_bot_is_target:
                     return
             else:
-                # Explicit /oq command: only the @mentioned bot (resolved recipient) handles it.
-                if not _this_bot_is_target:
+                # Explicit /oq command: the @mentioned bot handles it when a bot is mentioned.
+                # When no bot is explicitly mentioned (runtime placeholder recipients),
+                # Secretary forwards as the routing fallback so the control plane can
+                # route based on command grammar (e.g. `/oq ask administrator ...`).
+                _unaddressed = _is_runtime_placeholder_recipients(resolved_recipients)
+                if not _this_bot_is_target and not (
+                    _unaddressed and self._config.bot_role == "secretary"
+                ):
                     return
         project_id = parsed.project_id
         if project_id is None and chat_class == "project":


### PR DESCRIPTION
## Summary

- **Bug:** `/oq ask administrator what is my name?` typed in a group channel without a Discord `@OpenQilin Administrator` mention produced complete silence. The second gate in `on_message` blocked all bots (including Secretary) for explicit commands when no bot was @mentioned, so the message was never forwarded to the control plane.
- **Fix:** When `resolved_recipients` is the runtime placeholder (no Discord mention), Secretary now forwards the explicit command as a routing fallback. The control plane grammar parser resolves `administrator` as the target and dispatches accordingly.
- **Note:** The `@everyone` connector errors are from transient Docker networking — the route handler is `def` (FastAPI runs it in a thread pool already), so there is no async blocking issue.

## Test plan

- [ ] `/oq ask administrator what is my name?` in a group channel (no @mention) → Administrator responds
- [ ] `/oq ask ceo <question>` → CEO responds
- [ ] `@OpenQilin CEO /oq ask ceo <question>` → still works (existing path unchanged)
- [ ] 880 unit/component tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)